### PR TITLE
WIP .NET Core support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -193,3 +193,6 @@ FakesAssemblies/
 
 # Repo tests
 [Tt]est[Rr]epo/
+
+#Cake Artifacts
+[Aa]rtifacts/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,27 @@
 language: csharp
-script:
-  - ./build.sh
 os:
-  - linux
   - osx
-cache:
-  directories:
-    - src/packages
-    - tools
+  - linux
+
+# .NET CLI require Ubuntu 14.04
+sudo: required
+dist: trusty
+addons:
+  apt:
+    packages:
+    - gettext
+    - libcurl4-openssl-dev
+    - libicu-dev
+    - libssl-dev
+    - libunwind8
+
+# .NET CLI require OSX 10.10
+osx_image: xcode8.3
+
+mono:
+  - 4.4.2
+
+dotnet: 1.0.4
+
+script:
+  - ./build.sh --verbosity diagnostic

--- a/ReleaseNotes.md
+++ b/ReleaseNotes.md
@@ -1,3 +1,7 @@
+### New in 0.16.0 (Released 2017/07/25)
+
+* Made portable
+
 ### New in 0.15.0 (Released 2017/06/01)
 
 * Added GitHasStagedChanges alias

--- a/build.cake
+++ b/build.cake
@@ -182,14 +182,20 @@ Task("Create-NuGet-Package")
     .IsDependentOn("Publish-Artifacts")
     .Does(() =>
 {
-    var native = GetFiles(artifactsRoot.FullPath + "/**/lib/**/*");
+    var native = GetFiles(artifactsRoot.FullPath + "/net45/lib/**/*");
     var cakeGit = GetFiles(artifactsRoot.FullPath + "/**/Cake.Git.dll");
     var libGit = GetFiles(artifactsRoot.FullPath + "/**/LibGit2Sharp*");
+    var coreNative = GetFiles(artifactsRoot.FullPath + "/netstandard1.6/lib/**/*") - GetFiles(artifactsRoot.FullPath + "/netstandard1.6/lib/**/x86/*");
 
     nuGetPackSettings.Files =  (native + libGit + cakeGit)
                                     .Where(file=>!file.FullPath.Contains("Cake.Core.") && !file.FullPath.Contains("/runtimes/"))
                                     .Select(file=>file.FullPath.Substring(artifactsRoot.FullPath.Length+1))
                                     .Select(file=>new NuSpecContent {Source = file, Target = "lib/" + file})
+                                    .Union(
+                                        coreNative
+                                            .Select(file=>file.FullPath.Substring(artifactsRoot.FullPath.Length+1))
+                                            .Select(file=>new NuSpecContent {Source = file, Target = "lib/netstandard1.6/" + new FilePath(file).GetFilename().FullPath})
+                                        )
                                     .ToArray();
 
     if (!DirectoryExists(nugetRoot))

--- a/build.cake
+++ b/build.cake
@@ -224,7 +224,7 @@ Task("Test")
         );
         DotNetCoreExecute(
             "./tools/Cake.CoreCLR/Cake.dll",
-            string.Concat("test.cake --target=", target == "Default" ? "Default-Tests" : "Local-Tests")
+            string.Concat("test.cake --verbosity=diagnostic --target=", target == "Default" ? "Default-Tests" : "Local-Tests")
             );
     };
 

--- a/build.cake
+++ b/build.cake
@@ -220,7 +220,7 @@ Task("Test")
     .Does(() =>
 {
     var package = nugetRoot + "Cake.Git." + semVersion + ".nupkg";
-    var addinDir = MakeAbsolute(Directory("./tools/Addins/Cake.Git/Cake.Git"));
+    var addinDir = MakeAbsolute(Directory("./tools/Addins/cake.git/Cake.Git"));
     if (DirectoryExists(addinDir))
     {
         DeleteDirectory(addinDir, true);

--- a/build.cake
+++ b/build.cake
@@ -122,7 +122,7 @@ Task("Restore")
         Information("Restoring {0}...", solution);
         DotNetCoreRestore(solution.FullPath, new DotNetCoreRestoreSettings {
                 Verbosity = DotNetCoreVerbosity.Minimal,
-                Sources = new [] { "https://api.nuget.org/v3/index.json" },
+                Sources = new [] { "https://api.nuget.org/v3/index.json", "https://dotnet.myget.org/F/dotnet-core/api/v3/index.json" },
                 MSBuildSettings = msBuildSettings
         });
     }

--- a/build.ps1
+++ b/build.ps1
@@ -78,12 +78,12 @@ Set-Location $TOOLS_DIR
 # Restore packages
 if (Test-Path $PACKAGES_CONFIG)
 {
-    Invoke-Expression "&`"$NUGET_EXE`" install -ExcludeVersion -Source `"https://www.myget.org/F/devlead/api/v3/index.json`""
+    Invoke-Expression "&`"$NUGET_EXE`" install -ExcludeVersion -Source `"https://www.myget.org/F/cake/api/v3/index.json`""
 }
 # Install just Cake if missing config
 else
 {
-    Invoke-Expression "&`"$NUGET_EXE`" install Cake -ExcludeVersion -Source `"https://www.myget.org/F/devlead/api/v3/index.json`""
+    Invoke-Expression "&`"$NUGET_EXE`" install Cake -ExcludeVersion -Source `"https://www.myget.org/F/cake/api/v3/index.json`""
 }
 Pop-Location
 if ($LASTEXITCODE -ne 0)

--- a/build.ps1
+++ b/build.ps1
@@ -78,12 +78,12 @@ Set-Location $TOOLS_DIR
 # Restore packages
 if (Test-Path $PACKAGES_CONFIG)
 {
-    Invoke-Expression "&`"$NUGET_EXE`" install -ExcludeVersion"
+    Invoke-Expression "&`"$NUGET_EXE`" install -ExcludeVersion -Source `"https://www.myget.org/F/devlead/api/v3/index.json`""
 }
 # Install just Cake if missing config
 else
 {
-    Invoke-Expression "&`"$NUGET_EXE`" install Cake -ExcludeVersion"
+    Invoke-Expression "&`"$NUGET_EXE`" install Cake -ExcludeVersion -Source `"https://www.myget.org/F/devlead/api/v3/index.json`""
 }
 Pop-Location
 if ($LASTEXITCODE -ne 0)

--- a/build.sh
+++ b/build.sh
@@ -63,7 +63,7 @@ fi
 
 # Restore tools from NuGet.
 pushd $TOOLS_DIR >/dev/null
-mono $NUGET_EXE install -ExcludeVersion
+mono $NUGET_EXE install -ExcludeVersion -Source "https://www.myget.org/F/devlead/api/v3/index.json"
 if [ $? -ne 0 ]; then
     echo "Could not restore NuGet packages."
     exit 1

--- a/build.sh
+++ b/build.sh
@@ -63,7 +63,7 @@ fi
 
 # Restore tools from NuGet.
 pushd $TOOLS_DIR >/dev/null
-mono $NUGET_EXE install -ExcludeVersion -Source "https://www.myget.org/F/devlead/api/v3/index.json"
+mono $NUGET_EXE install -ExcludeVersion -Source "https://www.myget.org/F/cake/api/v3/index.json"
 if [ $? -ne 0 ]; then
     echo "Could not restore NuGet packages."
     exit 1

--- a/src/Cake.Git.sln
+++ b/src/Cake.Git.sln
@@ -1,22 +1,34 @@
-﻿
+
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio 14
-VisualStudioVersion = 14.0.24720.0
-MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cake.Git", "Cake.Git\Cake.Git.csproj", "{08F0A5C3-0E9C-451D-B003-14FF73699BE1}"
+# Visual Studio 15
+VisualStudioVersion = 15.0.26124.0
+MinimumVisualStudioVersion = 15.0.26124.0
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Cake.Git", "Cake.Git\Cake.Git.csproj", "{5BB38A2A-17AA-4FF6-8D2E-22CAAA008123}"
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
 		Release|Any CPU = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(ProjectConfigurationPlatforms) = postSolution
-		{08F0A5C3-0E9C-451D-B003-14FF73699BE1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{08F0A5C3-0E9C-451D-B003-14FF73699BE1}.Debug|Any CPU.Build.0 = Debug|Any CPU
-		{08F0A5C3-0E9C-451D-B003-14FF73699BE1}.Release|Any CPU.ActiveCfg = Release|Any CPU
-		{08F0A5C3-0E9C-451D-B003-14FF73699BE1}.Release|Any CPU.Build.0 = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{5BB38A2A-17AA-4FF6-8D2E-22CAAA008123}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{5BB38A2A-17AA-4FF6-8D2E-22CAAA008123}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{5BB38A2A-17AA-4FF6-8D2E-22CAAA008123}.Debug|x64.ActiveCfg = Debug|x64
+		{5BB38A2A-17AA-4FF6-8D2E-22CAAA008123}.Debug|x64.Build.0 = Debug|x64
+		{5BB38A2A-17AA-4FF6-8D2E-22CAAA008123}.Debug|x86.ActiveCfg = Debug|x86
+		{5BB38A2A-17AA-4FF6-8D2E-22CAAA008123}.Debug|x86.Build.0 = Debug|x86
+		{5BB38A2A-17AA-4FF6-8D2E-22CAAA008123}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{5BB38A2A-17AA-4FF6-8D2E-22CAAA008123}.Release|Any CPU.Build.0 = Release|Any CPU
+		{5BB38A2A-17AA-4FF6-8D2E-22CAAA008123}.Release|x64.ActiveCfg = Release|x64
+		{5BB38A2A-17AA-4FF6-8D2E-22CAAA008123}.Release|x64.Build.0 = Release|x64
+		{5BB38A2A-17AA-4FF6-8D2E-22CAAA008123}.Release|x86.ActiveCfg = Release|x86
+		{5BB38A2A-17AA-4FF6-8D2E-22CAAA008123}.Release|x86.Build.0 = Release|x86
 	EndGlobalSection
 EndGlobal

--- a/src/Cake.Git/Cake.Git.csproj
+++ b/src/Cake.Git/Cake.Git.csproj
@@ -39,4 +39,13 @@
     <PackageReference Include="LibGit2Sharp" Version="0.25.0-preview-0033" />
     <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="1.0.185" />
   </ItemGroup>
+
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
+    <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.11-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;fedora.24-x64;opensuse.13.2-x64;opensuse.42.1-x64</RuntimeIdentifiers>
+    <FrameworkPathOverride>$(NuGetPackageFolders)microsoft.targetingpack.netframework.v4.5\1.0.1\lib\net45\</FrameworkPathOverride>
+  </PropertyGroup>
+
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
+    <PackageReference Include="Microsoft.TargetingPack.NETFramework.v4.5" Version="1.0.1" ExcludeAssets="All" PrivateAssets="All" />
+  </ItemGroup>
 </Project>

--- a/src/Cake.Git/Cake.Git.csproj
+++ b/src/Cake.Git/Cake.Git.csproj
@@ -4,7 +4,8 @@
     <Copyright>WCOM AB</Copyright>
     <Authors>WCOMAB and contributors</Authors>
     <TargetFrameworks>netstandard1.6;net45</TargetFrameworks>
-    <PlatformTarget>AnyCpu</PlatformTarget>
+    <PlatformTarget Condition=" '$(TargetFramework)' == 'net45' ">x64</PlatformTarget>
+    <PlatformTarget Condition=" '$(TargetFramework)' != 'net45' ">AnyCpu</PlatformTarget>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Cake.Git</AssemblyName>
     <PackageId>Cake.Git</PackageId>

--- a/src/Cake.Git/Cake.Git.csproj
+++ b/src/Cake.Git/Cake.Git.csproj
@@ -1,114 +1,42 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<Project ToolsVersion="14.0" DefaultTargets="Build" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
-  <Import Project="..\packages\LibGit2Sharp.NativeBinaries.1.0.165\build\LibGit2Sharp.NativeBinaries.props" Condition="Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.165\build\LibGit2Sharp.NativeBinaries.props')" />
-  <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
-  <PropertyGroup>
-    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
-    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
-    <ProjectGuid>{08F0A5C3-0E9C-451D-B003-14FF73699BE1}</ProjectGuid>
-    <OutputType>Library</OutputType>
-    <AppDesignerFolder>Properties</AppDesignerFolder>
-    <RootNamespace>Cake.Git</RootNamespace>
-    <AssemblyName>Cake.Git</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
-    <FileAlignment>512</FileAlignment>
-    <NuGetPackageImportStamp>
-    </NuGetPackageImportStamp>
-    <TargetFrameworkProfile />
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
-    <DebugSymbols>true</DebugSymbols>
-    <DebugType>full</DebugType>
-    <Optimize>false</Optimize>
-    <OutputPath>bin\Debug\</OutputPath>
-    <DefineConstants>DEBUG;TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <DocumentationFile>bin\Debug\Cake.Git.XML</DocumentationFile>
-  </PropertyGroup>
-  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>pdbonly</DebugType>
-    <Optimize>true</Optimize>
-    <OutputPath>bin\Release\</OutputPath>
-    <DefineConstants>TRACE</DefineConstants>
-    <ErrorReport>prompt</ErrorReport>
-    <WarningLevel>4</WarningLevel>
-    <DocumentationFile>bin\Release\Cake.Git.XML</DocumentationFile>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Cake.Core, Version=0.18.0.0, Culture=neutral, processorArchitecture=MSIL">
-      <HintPath>..\packages\Cake.Core.0.18.0\lib\net45\Cake.Core.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="LibGit2Sharp, Version=0.24.0.0, Culture=neutral, PublicKeyToken=7cbde695407f0333, processorArchitecture=MSIL">
-      <HintPath>..\packages\LibGit2Sharp.Portable.0.24.10\lib\net40\LibGit2Sharp.dll</HintPath>
-      <Private>True</Private>
-    </Reference>
-    <Reference Include="System" />
-    <Reference Include="System.Core" />
-    <Reference Include="System.Xml.Linq" />
-    <Reference Include="System.Data.DataSetExtensions" />
-    <Reference Include="System.Data" />
-    <Reference Include="System.Net.Http" />
-    <Reference Include="System.Xml" />
-  </ItemGroup>
-  <ItemGroup>
-    <Compile Include="GitAliases.Unstage.cs" />
-    <Compile Include="GitAliases.Repository.cs" />
-    <Compile Include="GitAliases.Reset.cs" />
-    <Compile Include="GitAliases.Branch.cs" />
-    <Compile Include="GitAliases.Checkout.cs" />
-    <Compile Include="Extensions\RepositoryExtensions.cs" />
-    <Compile Include="GitAliases.Add.cs" />
-    <Compile Include="GitAliases.Clone.cs" />
-    <Compile Include="Extensions\PathExtensions.cs" />
-    <Compile Include="GitAliases.Commit.cs" />
-    <Compile Include="GitAliases.cs" />
-    <Compile Include="GitAliases.Describe.cs" />
-    <Compile Include="GitAliases.Diff.cs" />
-    <Compile Include="GitAliases.Init.cs" />
-    <Compile Include="GitAliases.Log.cs" />
-    <Compile Include="GitAliases.Pull.cs" />
-    <Compile Include="GitAliases.Push.cs" />
-    <Compile Include="GitAliases.Tag.cs" />
-    <Compile Include="GitBranch.cs" />
-    <Compile Include="GitChangeKind.cs" />
-    <Compile Include="GitCloneSettings.cs" />
-    <Compile Include="GitCommit.cs" />
-    <Compile Include="GitDescribeStrategy.cs" />
-    <Compile Include="GitDiffFile.cs" />
-    <Compile Include="GitMergeResult.cs" />
-    <Compile Include="GitMergeStatus.cs" />
-    <Compile Include="GitRemote.cs" />
-    <Compile Include="GitResetMode.cs" />
-    <Compile Include="GitSignature.cs" />
-    <Compile Include="Properties\AssemblyInfo.cs" />
-    <Compile Include="Properties\Namespaces.cs" />
-    <Compile Include="..\SolutionInfo.cs">
-      <Link>Properties\SolutionInfo.cs</Link>
-    </Compile>
-    <Compile Include="GitAliases.Remove.cs" />
-  </ItemGroup>
-  <ItemGroup>
-    <None Include="..\..\LICENSE.md">
-      <Link>LICENSE.md</Link>
-      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
-    </None>
-    <None Include="packages.config" />
-  </ItemGroup>
-  <ItemGroup />
-  <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
-    </PropertyGroup>
-    <Error Condition="!Exists('..\packages\LibGit2Sharp.NativeBinaries.1.0.165\build\LibGit2Sharp.NativeBinaries.props')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\LibGit2Sharp.NativeBinaries.1.0.165\build\LibGit2Sharp.NativeBinaries.props'))" />
-  </Target>
-  <!-- To modify your build process, add your task inside one of the targets below and uncomment it.
-       Other similar extension points exist, see Microsoft.Common.targets.
-  <Target Name="BeforeBuild">
-  </Target>
-  <Target Name="AfterBuild">
-  </Target>
-  -->
+    <Description>The Cake core library.</Description>
+    <Copyright>WCOM AB</Copyright>
+    <Authors>WCOMAB and contributors</Authors>
+    <TargetFrameworks>netstandard1.6;net45</TargetFrameworks>
+    <PlatformTarget>AnyCpu</PlatformTarget>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <AssemblyName>Cake.Git</AssemblyName>
+    <PackageId>Cake.Git</PackageId>
+    <PackageTags>Cake;Script;Build;Git</PackageTags>
+    <PackageIconUrl>http://cdn.rawgit.com/WCOMAB/nugetpackages/master/Chocolatey/icons/wcom.png</PackageIconUrl>
+    <PackageLicenseUrl>https://github.com/WCOMAB/Cake_Git/blob/master/LICENSE</PackageLicenseUrl>
+    <RepositoryType>git</RepositoryType>
+    <RepositoryUrl>https://github.com/WCOMAB/Cake_Git/</RepositoryUrl>
+    <OutputType>Library</OutputType>
+    <GenerateAssemblyTitleAttribute>false</GenerateAssemblyTitleAttribute>
+    <GenerateAssemblyDescriptionAttribute>false</GenerateAssemblyDescriptionAttribute>
+    <GenerateAssemblyProductAttribute>false</GenerateAssemblyProductAttribute>
+    <GenerateAssemblyVersionAttribute>false</GenerateAssemblyVersionAttribute>
+    <GenerateAssemblyFileVersionAttribute>false</GenerateAssemblyFileVersionAttribute>
+    <GenerateAssemblyInformationalVersionAttribute>false</GenerateAssemblyInformationalVersionAttribute>
+    <GenerateAssemblyCopyrightAttribute>false</GenerateAssemblyCopyrightAttribute>
+    <GenerateAssemblyCompanyAttribute>false</GenerateAssemblyCompanyAttribute>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <Compile Include="..\SolutionInfo.cs" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Content Include="..\..\LICENSE" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Cake.Core" Version="0.17.0">
+      <PrivateAssets>All</PrivateAssets>
+    </PackageReference>
+    <PackageReference Include="LibGit2Sharp" Version="0.25.0-preview-0033" />
+    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="1.0.185" />
+  </ItemGroup>
 </Project>

--- a/src/Cake.Git/Cake.Git.csproj
+++ b/src/Cake.Git/Cake.Git.csproj
@@ -3,9 +3,9 @@
     <Description>The Cake core library.</Description>
     <Copyright>WCOM AB</Copyright>
     <Authors>WCOMAB and contributors</Authors>
-    <TargetFrameworks>netstandard1.6;net45</TargetFrameworks>
-    <PlatformTarget Condition=" '$(TargetFramework)' == 'net45' ">x64</PlatformTarget>
-    <PlatformTarget Condition=" '$(TargetFramework)' != 'net45' ">AnyCpu</PlatformTarget>
+    <TargetFrameworks>netstandard1.6;net46</TargetFrameworks>
+    <PlatformTarget Condition=" '$(TargetFramework)' == 'net46' ">x64</PlatformTarget>
+    <PlatformTarget Condition=" '$(TargetFramework)' != 'net46' ">AnyCpu</PlatformTarget>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <AssemblyName>Cake.Git</AssemblyName>
     <PackageId>Cake.Git</PackageId>
@@ -34,19 +34,15 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Cake.Core" Version="0.17.0">
+    <PackageReference Include="Cake.Core" Version="0.22.0-alpha0075">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
     <PackageReference Include="LibGit2Sharp" Version="0.25.0-preview-0033" />
     <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="1.0.185" />
   </ItemGroup>
 
-  <PropertyGroup Condition=" '$(TargetFramework)' == 'net45' ">
+  <PropertyGroup Condition=" '$(TargetFramework)' == 'net46' ">
     <RuntimeIdentifiers>win7-x64;win7-x86;osx.10.11-x64;ubuntu.14.04-x64;ubuntu.16.04-x64;ubuntu.16.10-x64;centos.7-x64;rhel.7.2-x64;debian.8-x64;fedora.23-x64;fedora.24-x64;opensuse.13.2-x64;opensuse.42.1-x64</RuntimeIdentifiers>
-    <FrameworkPathOverride>$(NuGetPackageFolders)microsoft.targetingpack.netframework.v4.5\1.0.1\lib\net45\</FrameworkPathOverride>
   </PropertyGroup>
 
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <PackageReference Include="Microsoft.TargetingPack.NETFramework.v4.5" Version="1.0.1" ExcludeAssets="All" PrivateAssets="All" />
-  </ItemGroup>
 </Project>

--- a/src/Cake.Git/Extensions/PathExtensions.cs
+++ b/src/Cake.Git/Extensions/PathExtensions.cs
@@ -8,6 +8,8 @@ namespace Cake.Git.Extensions
 {
     internal static class PathExtensions
     {
+        private static readonly Uri FileUri = new Uri("file://");
+
         internal static Path MakeRelativePath(this Path path, ICakeEnvironment environment, DirectoryPath rootDirectoryPath)
         {
             if (path == null)
@@ -46,13 +48,12 @@ namespace Cake.Git.Extensions
             {
                 throw new ArgumentNullException(nameof(rootDirectoryPath));
             }
-            
-            var fileUri = new Uri(filePath.MakeAbsolute(environment).FullPath);
-            var rootUri = new Uri($"{rootDirectoryPath.MakeAbsolute(environment).FullPath}/");
+
+            var fileUri = new Uri(FileUri, filePath.MakeAbsolute(environment).FullPath);
+            var rootUri = new Uri(FileUri, $"{rootDirectoryPath.MakeAbsolute(environment).FullPath}/");
 
             var relativeUri = rootUri.MakeRelativeUri(fileUri);
             var relativePath = Uri.UnescapeDataString(relativeUri.ToString());
-
             var relativeFilePath = new FilePath(relativePath);
 
             return relativeFilePath;
@@ -75,12 +76,11 @@ namespace Cake.Git.Extensions
                 throw new ArgumentNullException(nameof(rootDirectoryPath));
             }
 
-            var dirUri = new Uri(directoryPath.MakeAbsolute(environment).FullPath);
-            var rootUri = new Uri($"{rootDirectoryPath.MakeAbsolute(environment).FullPath}/");
+            var dirUri = new Uri(FileUri, directoryPath.MakeAbsolute(environment).FullPath);
+            var rootUri = new Uri(FileUri, $"{rootDirectoryPath.MakeAbsolute(environment).FullPath}/");
 
             var relativeUri = rootUri.MakeRelativeUri(dirUri);
             var relativePath = Uri.UnescapeDataString(relativeUri.ToString());
-
             var relativeDirectoryPath = new DirectoryPath(relativePath);
 
             return relativeDirectoryPath;

--- a/src/Cake.Git/packages.config
+++ b/src/Cake.Git/packages.config
@@ -1,6 +1,0 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
-<packages>
-  <package id="Cake.Core" version="0.18.0" targetFramework="net45" />
-  <package id="LibGit2Sharp.NativeBinaries" version="1.0.165" targetFramework="net45" />
-  <package id="LibGit2Sharp.Portable" version="0.24.10" targetFramework="net45" />
-</packages>

--- a/src/SolutionInfo.cs
+++ b/src/SolutionInfo.cs
@@ -10,9 +10,9 @@ using System;
 [assembly: AssemblyDescription("Cake Git AddIn")]
 [assembly: AssemblyCompany("WCOM AB")]
 [assembly: AssemblyProduct("Cake.Git")]
-[assembly: AssemblyVersion("0.15.0")]
-[assembly: AssemblyFileVersion("0.15.0")]
-[assembly: AssemblyInformationalVersion("0.15.0")]
+[assembly: AssemblyVersion("0.16.0")]
+[assembly: AssemblyFileVersion("0.16.0")]
+[assembly: AssemblyInformationalVersion("0.16.0")]
 [assembly: AssemblyCopyright("Copyright © WCOM AB 2017")]
 [assembly: CLSCompliant(true)]
 

--- a/test.cake
+++ b/test.cake
@@ -1,4 +1,4 @@
-#addin "Cake.Git"
+#addin "nuget:?package=Cake.Git"
 using System.Security.Cryptography;
 
 ///////////////////////////////////////////////////////////////////////////////
@@ -171,7 +171,7 @@ Task("Git-HasUncommitedChanges-Dirty")
     .Does(() =>
 {
     Information("Checking if repository has uncommited changes...");
-    if (!GitHasUncommitedChanges(testInitalRepo)) 
+    if (!GitHasUncommitedChanges(testInitalRepo))
     {
         throw new Exception("Repository doesn't report uncommited changes.");
     };
@@ -182,7 +182,7 @@ Task("Git-HasUncommitedChanges-Clean")
     .Does(() =>
 {
     Information("Checking if repository has uncommited changes...");
-    if (GitHasUncommitedChanges(testInitalRepo)) 
+    if (GitHasUncommitedChanges(testInitalRepo))
     {
         throw new Exception("Repository reports uncommited changes after commiting all files.");
     };
@@ -328,12 +328,12 @@ Task("Git-Modify-Unstage")
     .Does(() =>
 {
     Information("Unstaging added test files...");
-    if (!GitHasStagedChanges(testInitalRepo)) 
+    if (!GitHasStagedChanges(testInitalRepo))
     {
         throw new Exception("Repository doesn't report indexed changes.");
     };
     GitUnstageAll(testInitalRepo);
-    if (GitHasStagedChanges(testInitalRepo)) 
+    if (GitHasStagedChanges(testInitalRepo))
     {
         throw new Exception("Repository does report indexed changes.");
     };
@@ -677,11 +677,11 @@ public static void CreateRandomDataFile(ICakeContext context, FilePath filePath)
 {
     var file = context.FileSystem.GetFile(filePath);
 
-    using (var rngCsp = new RNGCryptoServiceProvider())
+    using (var rngCsp = RandomNumberGenerator.Create())
     {
         var data = new byte[128];
         rngCsp.GetBytes(data);
-        var base64Data = Convert.ToBase64String(data, Base64FormattingOptions.InsertLineBreaks);
+        var base64Data = Convert.ToBase64String(data);
         using(var stream = file.OpenWrite())
         {
             using(var writer = new System.IO.StreamWriter(stream, Encoding.ASCII))

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-	<package id="Cake" version="0.21.1" />
-    <package id="Cake.CoreCLR" version="0.21.1" />
+	<package id="Cake" version="0.22.0-PullRequest1695" />
+    <package id="Cake.CoreCLR" version="0.22.0-PullRequest1695" />
 </packages>

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-	<package id="Cake" version="0.22.0-PullRequest1695" />
-    <package id="Cake.CoreCLR" version="0.22.0-PullRequest1695" />
+	<package id="Cake" version="0.22.0-alpha0075" />
+    <package id="Cake.CoreCLR" version="0.22.0-alpha0075" />
 </packages>

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-	<package id="Cake" version="0.17.0" />
+	<package id="Cake" version="0.21.1" />
+    <package id="Cake.CoreCLR" version="0.21.1" />
 </packages>


### PR DESCRIPTION
- [x] Port to VS2017
- [x] Multitarget .NET Core & .NET Full
- [x] Port build & test script to .NET Core 
- [x] Currently something like cake-build/cake#1695 is needed to be able to use lib & framwork moniker.
~~- [ ] Seeing issues with .NET Core not finding / looking for native assemblies in same places as Full .NET.~~
_Currently limited to x64 support on .NET Core Windows, because native framework path issues_