### PR TITLE
Use Tags category for all tag related aliases

### DIFF
--- a/src/Cake.Git/GitAliases.Tag.cs
+++ b/src/Cake.Git/GitAliases.Tag.cs
@@ -25,7 +25,7 @@ namespace Cake.Git
         /// <param name="tagName">The tag name.</param>
         /// <exception cref="ArgumentNullException"></exception>
         [CakeMethodAlias]
-        [CakeAliasCategory("Tag")]
+        [CakeAliasCategory("Tags")]
         public static void GitTag(
             this ICakeContext context,
             DirectoryPath repositoryDirectoryPath,

--- a/src/Cake.Git/GitAliases.Tags.cs
+++ b/src/Cake.Git/GitAliases.Tags.cs
@@ -18,7 +18,7 @@ namespace Cake.Git
         /// <param name="repositoryDirectoryPath"></param>
         /// <exception cref="ArgumentNullException"></exception>
         [CakeMethodAlias]
-        [CakeAliasCategory("AllTags")]
+        [CakeAliasCategory("Tags")]
         public static List<Tag> GitTags(
             this ICakeContext context,
             DirectoryPath repositoryDirectoryPath)


### PR DESCRIPTION
Use single Tags category for all tag related aliases to simplify discovery on Cake website