### PR TITLE
Use Branch category for all branch related aliases

### DIFF
--- a/src/Cake.Git/GitAliases.Branch.cs
+++ b/src/Cake.Git/GitAliases.Branch.cs
@@ -67,7 +67,6 @@ namespace Cake.Git
         ///   </code>
         /// </example>
         [CakeMethodAlias]
-        [CakeAliasCategory("CreateBranch")]
         public static void GitCreateBranch(this ICakeContext context, DirectoryPath repositoryDirectoryPath, string branchName, bool checkOut)
         {
             if (context == null)


### PR DESCRIPTION
Use single Branch category for all branching related aliases to simplify discovery on Cake website