### PR TITLE
Update to LibGit2Sharp 0.26.0

### DIFF
--- a/src/Cake.Git/Cake.Git.csproj
+++ b/src/Cake.Git/Cake.Git.csproj
@@ -20,8 +20,8 @@
     <PackageReference Include="Cake.Core" Version="0.28.1">
       <PrivateAssets>All</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="LibGit2Sharp" Version="0.25.2" />
-    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="1.0.217" />
+    <PackageReference Include="LibGit2Sharp" Version="0.26.0" />
+    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="2.0.267" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <Reference Include="Microsoft.CSharp" />


### PR DESCRIPTION
Update to LibGit2Sharp 0.26.0. This fixes an issue I experienced with LibGit2Sharp 0.25.2 which reported wrong file status for files added to the workspace which are ignored.