### PR TITLE
Update LibGit2Sharp to 0.26.0

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -203,13 +203,15 @@ Task("Create-NuGet-Package")
     var cakeGit = GetFiles(artifactsRoot.FullPath + "/**/Cake.Git.dll");
     var libGit = GetFiles(artifactsRoot.FullPath + "/**/LibGit2Sharp*");
     var coreNative = GetFiles(artifactsRoot.FullPath + "/netstandard2.0/runtimes/**/*")
-                        - GetFiles(artifactsRoot.FullPath + "/netstandard2.0/runtimes/win7-x86/**/*");
+                        - GetFiles(artifactsRoot.FullPath + "/netstandard2.0/runtimes/win-x86/**/*");
+
     nuGetPackSettings.Files =  (native + libGit + cakeGit)
                                     .Where(file=>!file.FullPath.Contains("Cake.Core.") && !file.FullPath.Contains("/runtimes/"))
                                     .Select(file=>file.FullPath.Substring(artifactsRoot.FullPath.Length+1))
                                     .Select(file=>new NuSpecContent {Source = file, Target = "lib/" + file})
                                     .Union(
                                         coreNative
+                                            .Where(file=>file.FullPath.Contains("/linux-x64/") || file.FullPath.Contains("/win-x64/") || file.FullPath.Contains("/osx/"))
                                             .Select(file=>new NuSpecContent {
                                                 Source = file.FullPath.Substring(artifactsRoot.FullPath.Length+1),
                                                 Target = "lib/netstandard2.0/" + file.GetFilename()

--- a/src/Cake.Git/Cake.Git.csproj
+++ b/src/Cake.Git/Cake.Git.csproj
@@ -18,8 +18,8 @@
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Cake.Core" Version="0.33.0" PrivateAssets="All" />
-    <PackageReference Include="LibGit2Sharp" Version="0.25.2" />
-    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="1.0.217" />
+    <PackageReference Include="LibGit2Sharp" Version="0.26.0" />
+    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="2.0.267" />
   </ItemGroup>
   <ItemGroup Condition=" '$(TargetFramework)' == 'net461' ">
     <Reference Include="Microsoft.CSharp" />


### PR DESCRIPTION
Updates LibGit2Sharp to 0.26.0.

Files comparison for `Executing task: Create-NuGet-Package`

* n: native
* c: cakeGit
* l: libGit
* cn: coreNative

## 0.25.2

```cmd
n: C:/Users/user/Documents/GitHub/Cake_Git/artifacts/net461/lib/osx/libgit2-6311e88.dylib
n: C:/Users/user/Documents/GitHub/Cake_Git/artifacts/net461/lib/linux/x86_64/libgit2-6311e88.so
n: C:/Users/user/Documents/GitHub/Cake_Git/artifacts/net461/lib/win32/x64/git2-6311e88.dll
n: C:/Users/user/Documents/GitHub/Cake_Git/artifacts/net461/lib/win32/x64/git2-6311e88.pdb
n: C:/Users/user/Documents/GitHub/Cake_Git/artifacts/net461/lib/win32/x86/git2-6311e88.dll
n: C:/Users/user/Documents/GitHub/Cake_Git/artifacts/net461/lib/win32/x86/git2-6311e88.pdb
c: C:/Users/user/Documents/GitHub/Cake_Git/artifacts/net461/Cake.Git.dll
c: C:/Users/user/Documents/GitHub/Cake_Git/artifacts/netstandard2.0/Cake.Git.dll
l: C:/Users/user/Documents/GitHub/Cake_Git/artifacts/net461/LibGit2Sharp.dll
l: C:/Users/user/Documents/GitHub/Cake_Git/artifacts/net461/LibGit2Sharp.dll.config
l: C:/Users/user/Documents/GitHub/Cake_Git/artifacts/netstandard2.0/LibGit2Sharp.dll
cn: C:/Users/user/Documents/GitHub/Cake_Git/artifacts/netstandard2.0/runtimes/linux-x64/native/libgit2-6311e88.so
cn: C:/Users/user/Documents/GitHub/Cake_Git/artifacts/netstandard2.0/runtimes/osx/native/libgit2-6311e88.dylib
cn: C:/Users/user/Documents/GitHub/Cake_Git/artifacts/netstandard2.0/runtimes/win7-x64/native/git2-6311e88.dll
cn: C:/Users/user/Documents/GitHub/Cake_Git/artifacts/netstandard2.0/runtimes/win7-x64/native/git2-6311e88.pdb
```

## 0.26.0

```cmd
n: C:/Users/user/Documents/GitHub/Cake_Git/artifacts/net461/lib/alpine-x64/libgit2-572e4d8.so
n: C:/Users/user/Documents/GitHub/Cake_Git/artifacts/net461/lib/debian.9-x64/libgit2-572e4d8.so
n: C:/Users/user/Documents/GitHub/Cake_Git/artifacts/net461/lib/fedora-x64/libgit2-572e4d8.so
n: C:/Users/user/Documents/GitHub/Cake_Git/artifacts/net461/lib/linux-x64/libgit2-572e4d8.so
n: C:/Users/user/Documents/GitHub/Cake_Git/artifacts/net461/lib/osx/libgit2-572e4d8.dylib
n: C:/Users/user/Documents/GitHub/Cake_Git/artifacts/net461/lib/rhel-x64/libgit2-572e4d8.so
n: C:/Users/user/Documents/GitHub/Cake_Git/artifacts/net461/lib/ubuntu.18.04-x64/libgit2-572e4d8.so
n: C:/Users/user/Documents/GitHub/Cake_Git/artifacts/net461/lib/win32/x64/git2-572e4d8.dll
n: C:/Users/user/Documents/GitHub/Cake_Git/artifacts/net461/lib/win32/x64/git2-572e4d8.pdb
n: C:/Users/user/Documents/GitHub/Cake_Git/artifacts/net461/lib/win32/x86/git2-572e4d8.dll
n: C:/Users/user/Documents/GitHub/Cake_Git/artifacts/net461/lib/win32/x86/git2-572e4d8.pdb
c: C:/Users/user/Documents/GitHub/Cake_Git/artifacts/net461/Cake.Git.dll
c: C:/Users/user/Documents/GitHub/Cake_Git/artifacts/netstandard2.0/Cake.Git.dll
l: C:/Users/user/Documents/GitHub/Cake_Git/artifacts/net461/LibGit2Sharp.dll
l: C:/Users/user/Documents/GitHub/Cake_Git/artifacts/net461/LibGit2Sharp.dll.config
l: C:/Users/user/Documents/GitHub/Cake_Git/artifacts/netstandard2.0/LibGit2Sharp.dll
cn: C:/Users/user/Documents/GitHub/Cake_Git/artifacts/netstandard2.0/runtimes/alpine-x64/native/libgit2-572e4d8.so
cn: C:/Users/user/Documents/GitHub/Cake_Git/artifacts/netstandard2.0/runtimes/debian.9-x64/native/libgit2-572e4d8.so
cn: C:/Users/user/Documents/GitHub/Cake_Git/artifacts/netstandard2.0/runtimes/fedora-x64/native/libgit2-572e4d8.so
cn: C:/Users/user/Documents/GitHub/Cake_Git/artifacts/netstandard2.0/runtimes/linux-x64/native/libgit2-572e4d8.so
cn: C:/Users/user/Documents/GitHub/Cake_Git/artifacts/netstandard2.0/runtimes/osx/native/libgit2-572e4d8.dylib
cn: C:/Users/user/Documents/GitHub/Cake_Git/artifacts/netstandard2.0/runtimes/rhel-x64/native/libgit2-572e4d8.so
cn: C:/Users/user/Documents/GitHub/Cake_Git/artifacts/netstandard2.0/runtimes/ubuntu.18.04-x64/native/libgit2-572e4d8.so
cn: C:/Users/user/Documents/GitHub/Cake_Git/artifacts/netstandard2.0/runtimes/win-x64/native/git2-572e4d8.dll
cn: C:/Users/user/Documents/GitHub/Cake_Git/artifacts/netstandard2.0/runtimes/win-x64/native/git2-572e4d8.pdb
```

There was also a change from `/netstandard2.0/runtimes/win7-x64/` to `/netstandard2.0/runtimes/win-x64/`.