### PR TITLE
(GH-110) GitCreateBranch should return correct branch if not checked out

### DIFF
--- a/src/Cake.Git/GitAliases.Branch.cs
+++ b/src/Cake.Git/GitAliases.Branch.cs
@@ -94,7 +94,7 @@ namespace Cake.Git
                         Commands.Checkout(repository, localBranch);
                     }
 
-                    return new GitBranch(repository);
+                    return new GitBranch(repository, localBranch);
                 });
 
         }

--- a/src/Cake.Git/GitBranch.cs
+++ b/src/Cake.Git/GitBranch.cs
@@ -58,6 +58,21 @@ namespace Cake.Git
         }
 
         /// <summary>
+        /// Initializes a new instance of the <see cref="GitBranch"/> class for a LibGit2Sharp branch instance.
+        /// </summary>
+        /// <param name="repository">The repository.</param>
+        /// <param name="branch">The branch.</param>
+        internal GitBranch(Repository repository, Branch branch)
+        {
+            CanonicalName = branch.CanonicalName;
+            FriendlyName = branch.FriendlyName;
+            Tip = new GitCommit(branch.Tip);
+            IsRemote = branch.IsRemote;
+            RemoteName = branch.RemoteName;
+            Remotes = System.Linq.Enumerable.ToList(System.Linq.Enumerable.Select(repository.Network.Remotes, remote => new GitRemote(remote.Name, remote.PushUrl, remote.Url)));
+        }
+
+        /// <summary>
         /// Generates a string representation of <see cref="GitBranch"/>
         /// </summary>
         /// <returns><see cref="GitBranch"/> as string</returns>

--- a/test.cake
+++ b/test.cake
@@ -706,13 +706,26 @@ Task("Git-Current-Branch")
     Information("Current branch: {0}", branch);
 });
 
-Task("Git-Create-Branch")
+Task("Git-Create-Branch-With-Checkout")
 .Does(() =>
 {
-    var branchName = "Foo";
+    var branchName = "Foo-With-Checkout";
     var createdBranch = GitCreateBranch(testInitalRepo, branchName, true);
     if (createdBranch.FriendlyName != branchName)
         throw new Exception($"Incorrect Branch returned. Expected {branchName} and got {createdBranch.FriendlyName}");
+    var branch = GitBranchCurrent(testInitalRepo);
+    if (branch.FriendlyName != branchName)
+        throw new Exception($"Incorrect Branch created. Expected {branchName} and got {branch.FriendlyName}");
+});
+
+Task("Git-Create-Branch-Without-Checkout")
+.Does(() =>
+{
+    var branchName = "Foo-Without-Checkout";
+    var createdBranch = GitCreateBranch(testInitalRepo, branchName, false);
+    if (createdBranch.FriendlyName != branchName)
+        throw new Exception($"Incorrect Branch returned. Expected {branchName} and got {createdBranch.FriendlyName}");
+    GitCheckout(testInitalRepo, branchName);
     var branch = GitBranchCurrent(testInitalRepo);
     if (branch.FriendlyName != branchName)
         throw new Exception($"Incorrect Branch created. Expected {branchName} and got {branch.FriendlyName}");
@@ -855,7 +868,8 @@ Task("Default-Tests")
     .IsDependentOn("Git-Describe")
     .IsDependentOn("Git-Describe-Annotated")
     .IsDependentOn("Git-Current-Branch")
-    .IsDependentOn("Git-Create-Branch")
+    .IsDependentOn("Git-Create-Branch-With-Checkout")
+    .IsDependentOn("Git-Create-Branch-Without-Checkout")
     .IsDependentOn("Git-Remote-Branch")
     .IsDependentOn("Git-Checkout")
     .IsDependentOn("Git-AllTags")
@@ -888,7 +902,8 @@ Task("Local-Tests")
     .IsDependentOn("Git-Describe")
     .IsDependentOn("Git-Describe-Annotated")
     .IsDependentOn("Git-Current-Branch")
-    .IsDependentOn("Git-Create-Branch")
+    .IsDependentOn("Git-Create-Branch-With-Checkout")
+    .IsDependentOn("Git-Create-Branch-Without-Checkout")
     .IsDependentOn("Git-Remote-Branch")
     .IsDependentOn("Git-Checkout")
     .IsDependentOn("Git-AllTags")


### PR DESCRIPTION
`GitCreateBranch` should return the created branch even if `checkOut` is `false`.

To requirement to pass the `Repository` instance to the `GitBranch` constructor is a bit of a hack, but required since there's an `Remotes` property. Not sure what's the reason for this property as remotes are related to the repo and not a specific branch, and adding/removing from this list won't actually modify the remotes on the repo (but that would probably be another issue)