### PR TITLE
Add missing null reference checks

### DIFF
--- a/src/Cake.Git/GitBranch.cs
+++ b/src/Cake.Git/GitBranch.cs
@@ -1,4 +1,5 @@
-﻿using LibGit2Sharp;
+﻿using System;
+using LibGit2Sharp;
 // ReSharper disable MemberCanBePrivate.Global
 
 namespace Cake.Git
@@ -49,6 +50,11 @@ namespace Cake.Git
         /// <param name="repository">The repository.</param>
         public GitBranch(Repository repository)
         {
+            if (repository == null)
+            {
+                throw new ArgumentNullException(nameof(repository));
+            }
+
             CanonicalName = repository.Head.CanonicalName;
             FriendlyName = repository.Head.FriendlyName;
             Tip = new GitCommit(repository.Head.Tip);
@@ -64,6 +70,16 @@ namespace Cake.Git
         /// <param name="branch">The branch.</param>
         internal GitBranch(Repository repository, Branch branch)
         {
+            if (repository == null)
+            {
+                throw new ArgumentNullException(nameof(repository));
+            }
+
+            if (branch == null)
+            {
+                throw new ArgumentNullException(nameof(branch));
+            }
+
             CanonicalName = branch.CanonicalName;
             FriendlyName = branch.FriendlyName;
             Tip = new GitCommit(branch.Tip);

--- a/src/Cake.Git/GitCommit.cs
+++ b/src/Cake.Git/GitCommit.cs
@@ -53,7 +53,7 @@ namespace Cake.Git
         {
             if (commit == null)
             {
-                throw new ArgumentException("Source commit can't be null.", nameof(commit));
+                throw new ArgumentNullException(nameof(commit));
             }
 
             Sha = commit.Sha;

--- a/src/Cake.Git/GitDiffFile.cs
+++ b/src/Cake.Git/GitDiffFile.cs
@@ -1,3 +1,4 @@
+using System;
 using LibGit2Sharp;
 // ReSharper disable MemberCanBePrivate.Global
 
@@ -35,6 +36,11 @@ namespace Cake.Git
 
         internal GitDiffFile(TreeEntryChanges change)
         {
+            if (change == null)
+            {
+                throw new ArgumentNullException(nameof(change));
+            }
+
             Path = change.Path;
             OldPath = change.OldPath;
             Status = (GitChangeKind)change.Status;


### PR DESCRIPTION
Add missing null reference checks and make sure an `ArgumentNullException` is thrown in all cases