### PR TITLE
Use SPDX expression for license of NuGet package

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -43,7 +43,7 @@ var nuGetPackSettings   = new NuGetPackSettings {
                                 ProjectUrl              = new Uri("https://github.com/cake-contrib/Cake_Git/"),
                                 Repository              = new NuGetRepository { Type = "git", Url = "https://github.com/cake-contrib/Cake_Git.git" },
                                 IconUrl                 = new Uri("https://cdn.jsdelivr.net/gh/cake-contrib/graphics/png/cake-contrib-medium.png"),
-                                LicenseUrl              = new Uri("https://github.com/cake-contrib/Cake_Git/blob/master/LICENSE.md"),
+                                License                 = new NuSpecLicense { Type = "expression", Value = "MIT" },
                                 Copyright               = assemblyInfo.Copyright,
                                 ReleaseNotes            = releaseNotes.Notes.ToArray(),
                                 Tags                    = new [] {"Cake", "Script", "Build", "Git"},

--- a/tools/packages.config
+++ b/tools/packages.config
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <packages>
-	<package id="Cake" version="0.33.0" />
-    <package id="Cake.CoreCLR" version="0.33.0" />
+	<package id="Cake" version="0.36.0" />
+    <package id="Cake.CoreCLR" version="0.36.0" />
 </packages>


### PR DESCRIPTION
Use SPDX expression for license of NuGet package.

Also bumps Cake version used for building the addin to 0.36.0 to support required properties.