### PR TITLE
GH-127: Modify do/while in GitFindRootFromPath to avoid infinite loop

### DIFF
--- a/src/Cake.Git/GitAliases.Repository.cs
+++ b/src/Cake.Git/GitAliases.Repository.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.IO;
 using System.Linq;
 using Cake.Core;
 using Cake.Core.Annotations;
@@ -194,7 +195,7 @@ namespace Cake.Git
                 if (Repository.IsValid(fsPath.FullPath))
                     return fsPath;
                 var parentDir = fsPath.Combine("../").Collapse();
-                if (!context.FileSystem.Exist(parentDir))
+                if (!context.FileSystem.Exist(parentDir) || new DirectoryInfo(parentDir.FullPath).Parent == null)
                     throw new RepositoryNotFoundException($"Path '{path}' doesn't point at a valid Git repository or workdir.");
                 fsPath = parentDir;
             }

--- a/src/Cake.Git/GitAliases.Repository.cs
+++ b/src/Cake.Git/GitAliases.Repository.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.IO;
 using System.Linq;
 using Cake.Core;
 using Cake.Core.Annotations;
@@ -194,12 +193,42 @@ namespace Cake.Git
             {
                 if (Repository.IsValid(fsPath.FullPath))
                     return fsPath;
-                var parentDir = fsPath.Combine("../").Collapse();
-                if (!context.FileSystem.Exist(parentDir) || new DirectoryInfo(parentDir.FullPath).Parent == null)
+                var parentDir = GetParent(context, fsPath);
+                if (!context.FileSystem.Exist(parentDir) || GetParent(context, parentDir) == null)
                     throw new RepositoryNotFoundException($"Path '{path}' doesn't point at a valid Git repository or workdir.");
                 fsPath = parentDir;
             }
             while (true);
+        }
+        
+        // replace with DirectoryPath.GetParent(), once https://github.com/cake-build/cake/pull/3349/files
+        // ReSharper disable once InconsistentNaming
+        private static DirectoryPath GetParent(ICakeContext context, DirectoryPath path)
+        {
+            path = path.MakeAbsolute(context.Environment); // to be sure. It's no use splitting the segments of "."
+
+            if (path.Segments.Length == 1)
+            {
+                // one segment on Windows is e.g. "C:/" 
+                // on all other systems one segment is e.g "/home"
+                if (context.Environment.Platform.Family == PlatformFamily.Windows) 
+                {
+                    // no more parents
+                    return null;
+                }
+
+                // root ("/") is not really a segment for Cake, 
+                // so we return that directly.
+                return new DirectoryPath("/");
+            }
+            
+            if(path.Segments.Length == 0) 
+            {
+                return null;
+            }
+
+            var segments = path.Segments.Take(path.Segments.Length - 1);
+            return new DirectoryPath(string.Join(path.Separator.ToString(), segments));
         }
     }
 }

--- a/test.cake
+++ b/test.cake
@@ -477,6 +477,25 @@ Task("Git-Find-Root-From-Path")
         throw new Exception(string.Format("Wrong git root found (actual: {0}, expected: {1})", rootFolder, testInitalRepo));
 });
 
+Task("Git-Find-Root-From-Path-TempDirectory")
+    .Does(() => 
+{
+    var tempPath = System.IO.Path.GetTempPath();
+    Information("Attempting to resolve Git root directory from temp directory '{0}'...", tempPath);
+    try
+    {
+        var result = GitFindRootFromPath(tempPath);
+        throw new Exception(string.Format("Path at '{0}' should not be a valid Git repository.  Found Git root at '{1}'.",
+            tempPath, result.FullPath));
+    }
+    catch(LibGit2Sharp.RepositoryNotFoundException)
+    {
+        // this exception is expected when the directory traversal
+        // does not successfully identify a git repository.
+        Information("No repository located.  This is expected.");
+    }
+});
+
 Task("Git-Tag-Apply-Objectish")
     .IsDependentOn("Git-Modify-Commit")
     .Does(() =>
@@ -1086,6 +1105,7 @@ Task("Default-Tests")
     .IsDependentOn("Git-Clone-WithCredentialsAndSettings")
     .IsDependentOn("Git-Diff")
     .IsDependentOn("Git-Find-Root-From-Path")
+    .IsDependentOn("Git-Find-Root-From-Path-TempDirectory")
     .IsDependentOn("Git-Reset")
     .IsDependentOn("Git-Describe")
     .IsDependentOn("Git-Describe-Annotated")
@@ -1125,6 +1145,7 @@ Task("Local-Tests")
     .IsDependentOn("Git-Modify-Diff")
     .IsDependentOn("Git-Diff")
     .IsDependentOn("Git-Find-Root-From-Path")
+    .IsDependentOn("Git-Find-Root-From-Path-TempDirectory")
     .IsDependentOn("Git-Reset")
     .IsDependentOn("Git-Describe")
     .IsDependentOn("Git-Describe-Annotated")


### PR DESCRIPTION
This change addresses GH-127 to look at the current iteration of `parentDir` and provides a graceful termination consistent with the path simply not existing.  

Using `System.IO.DirectoryInfo` seemed to be the most straightforward/deterministic approach here; if there's a preferred approach, please feel free to suggest something different.