### PR TITLE
Remove publishing to MyGet

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Cake Git
 
-[![NuGet](https://img.shields.io/nuget/v/Cake.Git.svg)](https://www.nuget.org/packages/Cake.Git) [![MyGet](https://img.shields.io/myget/cake-contrib/vpre/Cake.Git.svg?label=MyGet)](https://www.myget.org/feed/wcomab/package/nuget/Cake.Git)
+[![NuGet](https://img.shields.io/nuget/v/Cake.Git.svg)](https://www.nuget.org/packages/Cake.Git)
 
 Cake AddIn that extends Cake with Git features using LibGit2 and LibGit2Sharp.
 

--- a/build.cake
+++ b/build.cake
@@ -269,36 +269,6 @@ Task("Test")
     executeTests();
 });
 
-
-
-Task("Publish-MyGet")
-    .IsDependentOn("Create-NuGet-Package")
-    .IsDependentOn("Test")
-    .WithCriteria(() => !isLocalBuild)
-    .WithCriteria(() => !isPullRequest)
-    .Does(() =>
-{
-    // Resolve the API key.
-    var apiKey = EnvironmentVariable("MYGET_API_KEY");
-    if(string.IsNullOrEmpty(apiKey)) {
-        throw new InvalidOperationException("Could not resolve MyGet API key.");
-    }
-
-    var source = EnvironmentVariable("MYGET_SOURCE");
-    if(string.IsNullOrEmpty(apiKey)) {
-        throw new InvalidOperationException("Could not resolve MyGet source.");
-    }
-
-    // Get the path to the package.
-    var package = nugetRoot + "Cake.Git." + semVersion + ".nupkg";
-
-    // Push the package.
-    NuGetPush(package, new NuGetPushSettings {
-        Source = source,
-        ApiKey = apiKey
-    });
-});
-
 Task("Upload-AppVeyor-Artifacts")
     .IsDependentOn("Create-NuGet-Package")
     .IsDependentOn("Test")
@@ -322,8 +292,7 @@ Task("Local-Tests")
     .IsDependentOn("Test");
 
 Task("AppVeyor")
-    .IsDependentOn("Upload-AppVeyor-Artifacts")
-    .IsDependentOn("Publish-MyGet");
+    .IsDependentOn("Upload-AppVeyor-Artifacts");
 
 Task("Travis")
     .IsDependentOn("Test");


### PR DESCRIPTION
Remove publishing of package to MyGet, since we run into issues with our quota.

If we want CI builds back we should migrate to Cake.Recipe which provides integration with GitHub packages (#104)