### PR TITLE
(#57) added an alias GitShortenSha

### DIFF
--- a/src/Cake.Git/GitAliases.ShortenSha.cs
+++ b/src/Cake.Git/GitAliases.ShortenSha.cs
@@ -24,7 +24,7 @@ namespace Cake.Git
         /// <param name="context">The context.</param>
         /// <param name="repositoryDirectoryPath">Path to repository.</param>
         /// <param name="commit">The Commit whose Sha should be shortened.</param>
-        /// <param name="minimalLength">The minimal length of the shortened SHA.</param>
+        /// <param name="minimalLength">The minimal length of the shortened SHA. The default is 7 (seven) characters.</param>
         /// <exception cref="ArgumentNullException"></exception>
         [CakeMethodAlias]
         [CakeAliasCategory("Sha")]

--- a/src/Cake.Git/GitAliases.ShortenSha.cs
+++ b/src/Cake.Git/GitAliases.ShortenSha.cs
@@ -1,0 +1,70 @@
+﻿using Cake.Core;
+using Cake.Core.Annotations;
+using Cake.Core.IO;
+using Cake.Git.Extensions;
+using LibGit2Sharp;
+using System;
+
+// ReSharper disable MemberCanBePrivate.Global
+// ReSharper disable UnusedMember.Global
+namespace Cake.Git
+{
+    // ReSharper disable once PublicMembersMustHaveComments
+    public static partial class GitAliases
+    {
+        /// <summary>
+        /// Get the short version of a commit SHA.
+        /// </summary>
+        /// <example>
+        /// <code>
+        /// var commit = GitLogTip("path/to/repo");
+        /// var shortSha = GitShortenSha("path/to/repo", commit);
+        /// </code>
+        /// </example>
+        /// <param name="context">The context.</param>
+        /// <param name="repositoryDirectoryPath">Path to repository.</param>
+        /// <param name="commit">The Commit whose Sha should be shortened.</param>
+        /// <param name="minimalLength">The minimal length of the shortened SHA.</param>
+        /// <exception cref="ArgumentNullException"></exception>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Sha")]
+        public static string GitShortenSha(
+            this ICakeContext context,
+            DirectoryPath repositoryDirectoryPath,
+            GitCommit commit,
+            int? minimalLength = null)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+            
+            if (repositoryDirectoryPath == null)
+            {
+                throw new ArgumentNullException(nameof(repositoryDirectoryPath));
+            }
+            
+            if (commit == null)
+            {
+                throw new ArgumentNullException(nameof(commit));
+            }
+
+            string shortSha = null;
+            
+            context.UseRepository(
+                repositoryDirectoryPath,
+                repository =>
+                {
+                    var obj = repository.Lookup(commit.Sha, ObjectType.Commit);
+                    shortSha = minimalLength.HasValue 
+                        ? repository.ObjectDatabase.ShortenObjectId(obj, minimalLength.Value) 
+                        : repository.ObjectDatabase.ShortenObjectId(obj);
+                }
+            );
+            
+            return shortSha;
+        }
+
+
+    }
+}

--- a/test.cake
+++ b/test.cake
@@ -855,7 +855,58 @@ Task("Git-Config")
     }
 });
 
+Task("Git-ShortenSha-length")
+    .IsDependentOn("Git-Init-Commit")
+    .Does(() =>
+{
+    // Arrange
+    const int min = 20;
+    var commit = GitLogTip(testInitalRepo);
 
+    // Act
+    var shortSha = GitShortenSha(testInitalRepo, commit, min);
+
+    Information("Sha      {0}", commit.Sha);
+    Information("ShortSha {0}", shortSha);
+    
+    if(shortSha.Length < min) 
+    {
+        throw new InvalidOperationException($"Short SHA is expected to have a minimal length of {min}.");
+    }
+
+    if(shortSha.Length >= commit.Sha.Length) 
+    {
+        throw new InvalidOperationException("Short SHA is expected to be shorter.");
+    }
+
+    if(!commit.Sha.StartsWith(shortSha)) 
+    {
+        throw new InvalidOperationException("Short SHA is expected to match the start of the full SHA.");
+    }
+});
+
+Task("Git-ShortenSha-no-length")
+    .IsDependentOn("Git-Init-Commit")
+    .Does(() =>
+{
+    // Arrange
+    var commit = GitLogTip(testInitalRepo);
+
+    // Act
+    var shortSha = GitShortenSha(testInitalRepo, commit);
+
+    Information("Sha      {0}", commit.Sha);
+    Information("ShortSha {0}", shortSha);
+    if(shortSha.Length >= commit.Sha.Length) 
+    {
+        throw new InvalidOperationException("Short SHA is expected to be shorter.");
+    }
+
+    if(!commit.Sha.StartsWith(shortSha)) 
+    {
+        throw new InvalidOperationException("Short SHA is expected to match the start of the full SHA.");
+    }
+});
 
 Task("Git-Tag")
     .IsDependentOn("Git-Tag-Apply")
@@ -902,6 +953,10 @@ Task("Git-HasUncommitedChanges")
     .IsDependentOn("Git-HasUncommitedChanges-Dirty")
     .IsDependentOn("Git-HasUncommitedChanges-Clean");
 
+Task("Git-ShortenSha")
+    .IsDependentOn("Git-ShortenSha-no-length")
+    .IsDependentOn("Git-ShortenSha-length");
+
 Task("Default-Tests")
     .IsDependentOn("Git-Init")
     .IsDependentOn("Git-IsValidRepository-LocalRepo")
@@ -941,7 +996,8 @@ Task("Default-Tests")
     .IsDependentOn("Git-AllTags-Annotated")
     .IsDependentOn("Git-AllTags-Targets")
     .IsDependentOn("Git-Clean")
-    .IsDependentOn("Git-Config");
+    .IsDependentOn("Git-Config")
+    .IsDependentOn("Git-ShortenSha");
 
 Task("Local-Tests")
     .IsDependentOn("Git-Init")
@@ -978,7 +1034,8 @@ Task("Local-Tests")
     .IsDependentOn("Git-AllTags-Annotated")
     .IsDependentOn("Git-AllTags-Targets")
     .IsDependentOn("Git-Clean")
-    .IsDependentOn("Git-Config");
+    .IsDependentOn("Git-Config")
+    .IsDependentOn("Git-ShortenSha");
 
 ///////////////////////////////////////////////////////////////////////////////
 // EXECUTION


### PR DESCRIPTION
to retrieve a shortened version of a commit SHA.

Since the required length of the short SHA is dependent on the repository (or rather on the IDs of all other objects in the database) the alias requires a path to a repository.

fixes #57 