### PR TITLE
Update LibGit2Sharp

### DIFF
--- a/build.cake
+++ b/build.cake
@@ -215,24 +215,18 @@ Task("Create-NuGet-Package")
 {
     var cakeGit = context.GetFiles(data.BuildPaths.ArtifactsRoot.FullPath + "/**/Cake.Git.dll");
     var cakeGitDoc = context.GetFiles(data.BuildPaths.ArtifactsRoot.FullPath + "/**/Cake.Git.xml");
-    var libGit = context.GetFiles(data.BuildPaths.ArtifactsRoot.FullPath + "/**/LibGit2Sharp*");
+    var libGitSharp = context.GetFiles(data.BuildPaths.ArtifactsRoot.FullPath + "/**/LibGit2Sharp*");
+    // cake scripting needs the unmanaged dlls to be in the "wrong" place for some reason..
+    var libGit = context.GetFiles(data.BuildPaths.ArtifactsRoot.FullPath + "/**/runtimes/**/*");
     var unmanaged = context.GetFiles(data.BuildPaths.ArtifactsRoot.FullPath + "/net6.0/runtimes/**/*");
 
-    data.NuGetPackSettings.Files =  (libGit + cakeGit + cakeGitDoc)
+    data.NuGetPackSettings.Files =  (libGitSharp + libGit + cakeGit + cakeGitDoc)
                                     .Select(file=>file.FullPath.Substring(data.BuildPaths.ArtifactsRoot.FullPath.Length+1))
                                     .Select(file=>new NuSpecContent {Source = file, Target = "lib/" + file})
                                     // add unmanaged dlls to the "right" place in the nuget
                                     .Union(unmanaged
                                         .Select(file=>file.FullPath.Substring(data.BuildPaths.ArtifactsRoot.FullPath.Length+1))
                                         .Select(file=>new NuSpecContent {Source = file, Target = "/" + file.Substring(7)}))
-                                    // cake scripting needs the unmanaged dlls to be in the "wrong" place for some reason..
-                                    .Union(unmanaged
-                                        .Where(file=>file.FullPath.Contains("/linux-x64/") || file.FullPath.Contains("/win-x64/") || file.FullPath.Contains("/osx/"))
-                                        .SelectMany(file => data.TargetFrameworks.Select(tfm =>
-                                            new NuSpecContent {
-                                                Source = file.FullPath.Substring(data.BuildPaths.ArtifactsRoot.FullPath.Length+1),
-                                                Target = $"lib/{tfm}/{file.GetFilename()}"
-                                            })))
                                     // add the icon
                                     .Union(new []
                                     {

--- a/src/Cake.Git/Cake.Git.csproj
+++ b/src/Cake.Git/Cake.Git.csproj
@@ -18,8 +18,7 @@
     <ProjectGuid>{08F0A5C3-0E9C-451D-B003-14FF73699BE1}</ProjectGuid>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="LibGit2Sharp" Version="0.27.0-preview-0102" />
-    <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="2.0.312" />
+    <PackageReference Include="LibGit2Sharp" Version="0.27.0-preview-0182" />
     <PackageReference Include="Cake.Core" Version="3.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
   </ItemGroup>


### PR DESCRIPTION
- Updates `LibGit2Sharp` and removes the explicit `LibGit2Sharp.NativeBinaries` reference because `LibGit2Sharp` is [tied to a specific libgit2 hash anyways](https://github.com/libgit2/libgit2sharp/blob/master/LibGit2Sharp/Core/NativeMethods.cs#L17)
- Includes natives for all architectures for cake scripting (before/after screenshot)
![image](https://user-images.githubusercontent.com/35262707/218867449-905ea8ca-72ec-4a97-8909-de37893e69d5.png)


Closes #166