### PR TITLE
Add GitRemotes() and GitRemote() aliases

### DIFF
--- a/src/Cake.Git/GitAliases.Remote.cs
+++ b/src/Cake.Git/GitAliases.Remote.cs
@@ -1,0 +1,92 @@
+﻿using Cake.Core;
+using Cake.Core.Annotations;
+using Cake.Core.IO;
+using Cake.Git.Extensions;
+using LibGit2Sharp;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+// ReSharper disable UnusedMember.Global
+
+namespace Cake.Git
+{
+    public static partial class GitAliases
+    {
+        /// <summary>
+        /// Gets a git repository's remotes.
+        /// </summary>
+        /// <example>
+        /// <code>
+        ///     var remotes = GitRemotes("c:/temp/cake");
+        /// </code>
+        /// </example>
+        /// <param name="context">The context.</param>
+        /// <param name="repositoryDirectoryPath">Path to repository.</param>
+        /// <returns>A list of <see cref="GitRemote"/> objects for the specified repository.</returns>
+        /// <exception cref="ArgumentNullException">If any of the parameters are null.</exception>
+        /// <exception cref="RepositoryNotFoundException">If path doesn't exist.</exception>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Remotes")]
+        public static IReadOnlyList<GitRemote> GitRemotes(this ICakeContext context, DirectoryPath repositoryDirectoryPath)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (repositoryDirectoryPath == null)
+            {
+                throw new ArgumentNullException(nameof(repositoryDirectoryPath));
+            }
+
+            if (!context.FileSystem.Exist(repositoryDirectoryPath))
+            {
+                throw new RepositoryNotFoundException($"Path '{repositoryDirectoryPath}' doesn't exists.");
+            }
+
+            return context.UseRepository(
+              repositoryDirectoryPath,
+              repository => repository.Network.Remotes.Select(remote => new GitRemote(remote.Name, remote.PushUrl, remote.Url)).ToList()
+              );
+        }
+
+        /// <summary>
+        /// Gets the specified remote from a git repository.
+        /// </summary>
+        /// <example>
+        /// <code>
+        ///     var remotes = GitRemote("c:/temp/cake", "origin");
+        /// </code>
+        /// </example>
+        /// <param name="context">The context.</param>
+        /// <param name="repositoryDirectoryPath">Path to repository.</param>
+        /// <param name="remoteName">The name of the remote to get.</param>
+        /// <returns>Information about the requested remote or null if no matching remote was found.</returns>
+        /// <exception cref="ArgumentNullException">If any of the parameters are null.</exception>
+        /// <exception cref="RepositoryNotFoundException">If path doesn't exist.</exception>
+        [CakeMethodAlias]
+        [CakeAliasCategory("Remotes")]
+        public static GitRemote GitRemote(this ICakeContext context, DirectoryPath repositoryDirectoryPath, string remoteName)
+        {
+            if (context == null)
+            {
+                throw new ArgumentNullException(nameof(context));
+            }
+
+            if (repositoryDirectoryPath == null)
+            {
+                throw new ArgumentNullException(nameof(repositoryDirectoryPath));
+            }
+
+            if (!context.FileSystem.Exist(repositoryDirectoryPath))
+            {
+                throw new RepositoryNotFoundException($"Path '{repositoryDirectoryPath}' doesn't exists.");
+            }
+
+            return context.UseRepository(
+              repositoryDirectoryPath,
+              repository => repository.Network.Remotes[remoteName] is { } remote ? new GitRemote(remote.Name, remote.PushUrl, remote.Url) : null
+              );
+        }
+    }
+}

--- a/src/Cake.Git/GitAliases.Remote.cs
+++ b/src/Cake.Git/GitAliases.Remote.cs
@@ -6,18 +6,19 @@ using LibGit2Sharp;
 using System;
 using System.Collections.Generic;
 using System.Linq;
-// ReSharper disable UnusedMember.Global
 
+// ReSharper disable UnusedMember.Global
 namespace Cake.Git
 {
     public static partial class GitAliases
     {
         /// <summary>
-        /// Gets a git repository's remotes.
+        /// Gets a Git repository's remotes.
         /// </summary>
         /// <example>
         /// <code>
-        ///     var remotes = GitRemotes("c:/temp/cake");
+        ///     var remotes = GitRemotes("c:/myrepo");
+        ///     Information("Found remotes: {0}", string.Join(", ", remotes.Select(x => x.Name + " -> " + x.Url)));
         /// </code>
         /// </example>
         /// <param name="context">The context.</param>
@@ -29,15 +30,9 @@ namespace Cake.Git
         [CakeAliasCategory("Remotes")]
         public static IReadOnlyList<GitRemote> GitRemotes(this ICakeContext context, DirectoryPath repositoryDirectoryPath)
         {
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
-            if (repositoryDirectoryPath == null)
-            {
-                throw new ArgumentNullException(nameof(repositoryDirectoryPath));
-            }
+            ArgumentNullException.ThrowIfNull(repositoryDirectoryPath);
 
             if (!context.FileSystem.Exist(repositoryDirectoryPath))
             {
@@ -51,11 +46,12 @@ namespace Cake.Git
         }
 
         /// <summary>
-        /// Gets the specified remote from a git repository.
+        /// Gets the specified remote from a Git repository.
         /// </summary>
         /// <example>
         /// <code>
-        ///     var remotes = GitRemote("c:/temp/cake", "origin");
+        ///     GitRemote remote = GitRemote("c:/temp/cake", "origin");
+        ///     Information(remote.Url);
         /// </code>
         /// </example>
         /// <param name="context">The context.</param>
@@ -68,15 +64,9 @@ namespace Cake.Git
         [CakeAliasCategory("Remotes")]
         public static GitRemote GitRemote(this ICakeContext context, DirectoryPath repositoryDirectoryPath, string remoteName)
         {
-            if (context == null)
-            {
-                throw new ArgumentNullException(nameof(context));
-            }
+            ArgumentNullException.ThrowIfNull(context);
 
-            if (repositoryDirectoryPath == null)
-            {
-                throw new ArgumentNullException(nameof(repositoryDirectoryPath));
-            }
+            ArgumentNullException.ThrowIfNull(repositoryDirectoryPath);
 
             if (!context.FileSystem.Exist(repositoryDirectoryPath))
             {

--- a/test.cake
+++ b/test.cake
@@ -1025,6 +1025,68 @@ Task("Git-Fetch-Remote-Tags")
     }
 });
 
+Task("Git-Remotes")
+    .IsDependentOn("Git-Modify-Commit")
+    .Does(() =>
+{
+    var originDir = testRepo.Combine(Guid.NewGuid().ToString("d"));
+    var testDir = testRepo.Combine(Guid.NewGuid().ToString("d"));
+
+    try
+    {
+        // Arrange: create a repo and a clone
+        GitClone((IsRunningOnWindows() ? "" : "file://")+testInitialRepo.FullPath, originDir);
+        GitClone((IsRunningOnWindows() ? "" : "file://")+originDir.FullPath, testDir);
+
+        // Act
+        var remotes = GitRemotes(testDir);
+
+        // Assert
+        Information("Found remotes: {0}", string.Join(", ", remotes.Select(x => x.Name + " -> " + x.Url)));
+    }
+    finally
+    {
+        // cleanup
+        var settings = new DeleteDirectorySettings {
+            Recursive = true,
+            Force = true
+        };
+        DeleteDirectory(originDir, settings);
+        DeleteDirectory(testDir, settings);
+    }
+});
+
+Task("Git-Remote")
+    .IsDependentOn("Git-Modify-Commit")
+    .Does(() =>
+{
+    var originDir = testRepo.Combine(Guid.NewGuid().ToString("d"));
+    var testDir = testRepo.Combine(Guid.NewGuid().ToString("d"));
+
+    try
+    {
+        // Arrange: create a repo and a clone
+        GitClone((IsRunningOnWindows() ? "" : "file://")+testInitialRepo.FullPath, originDir);
+        GitClone((IsRunningOnWindows() ? "" : "file://")+originDir.FullPath, testDir);
+
+        // Act
+        var remote = GitRemote(testDir, "origin");
+
+        // Assert
+        Information("Found remote: {0}", remote.Url);
+    }
+    finally
+    {
+        // cleanup
+        var settings = new DeleteDirectorySettings {
+            Recursive = true,
+            Force = true
+        };
+        DeleteDirectory(originDir, settings);
+        DeleteDirectory(testDir, settings);
+    }
+});
+
 Task("Git-Tag")
     .IsDependentOn("Git-Tag-Apply")
     .IsDependentOn("Git-Tag-Apply-Objectish");
@@ -1120,7 +1182,9 @@ Task("Default-Tests")
     .IsDependentOn("Git-Clean")
     .IsDependentOn("Git-Config")
     .IsDependentOn("Git-ShortenSha")
-    .IsDependentOn("Git-Fetch-Remote");
+    .IsDependentOn("Git-Fetch-Remote")
+    .IsDependentOn("Git-Remotes")
+    .IsDependentOn("Git-Remote");
 
 Task("Local-Tests")
     .IsDependentOn("Git-Init")
@@ -1160,7 +1224,9 @@ Task("Local-Tests")
     .IsDependentOn("Git-Clean")
     .IsDependentOn("Git-Config")
     .IsDependentOn("Git-ShortenSha")
-    .IsDependentOn("Git-Fetch-Remote");
+    .IsDependentOn("Git-Fetch-Remote")
+    .IsDependentOn("Git-Remotes")
+    .IsDependentOn("Git-Remote");
 
 ///////////////////////////////////////////////////////////////////////////////
 // EXECUTION


### PR DESCRIPTION
Add aliases to retrieve information about a git repository's remotes.

- GitRemotes(): List all of a repository's remotes
- GitRemote(): Get a specific remote by name (or `null` if no such remote exists)

It was already possible to get the remotes indirectly via the GitBranchCurrentAlias() but I found this counterintuitive and hard to discover.

I think it makes sense to have dedicated aliases for working with remotes as this git functionality is not directly tied to any branch.

Fixes partially #147