### PR TITLE
Update to Cake 5.0 and .NET 9

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "4.0.0",
+      "version": "5.0.0",
       "commands": [
         "dotnet-cake"
       ]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,9 +6,8 @@ install:
   - ps: $env:DOTNET_INSTALL_DIR = "$pwd\.dotnetsdk"
   - ps: mkdir $env:DOTNET_INSTALL_DIR -Force | Out-Null
   - ps: Invoke-WebRequest -Uri "https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.ps1" -OutFile "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1"
-  - ps: '& "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1" -Version 6.0.418 -InstallDir $env:DOTNET_INSTALL_DIR'
-  - ps: '& "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1" -Version 7.0.405 -InstallDir $env:DOTNET_INSTALL_DIR'
-  - ps: '& "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1" -Version 8.0.101 -InstallDir $env:DOTNET_INSTALL_DIR'
+  - ps: '& "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1" -Version 8.0.404 -InstallDir $env:DOTNET_INSTALL_DIR'
+  - ps: '& "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1" -Version 9.0.100 -InstallDir $env:DOTNET_INSTALL_DIR'
   - ps: $env:Path = "$env:DOTNET_INSTALL_DIR;$env:Path"
   - ps: dotnet --info
 

--- a/build.cake
+++ b/build.cake
@@ -76,7 +76,7 @@ Setup(ctx =>
         isLocalBuild,
         configuration,
         target,
-        new[]{ "net6.0", "net7.0", "net8.0" },
+        new[]{ "net8.0", "net9.0" },
         new DotNetMSBuildSettings()
                             .WithProperty("Version", semVersion)
                             .WithProperty("AssemblyVersion", version)
@@ -221,7 +221,7 @@ Task("Create-NuGet-Package-Scripting")
     var cakeGit = context.GetFiles(data.BuildPaths.ArtifactsRoot.FullPath + "/**/Cake.Git.dll");
     var cakeGitDoc = context.GetFiles(data.BuildPaths.ArtifactsRoot.FullPath + "/**/Cake.Git.xml");
     var libGit = context.GetFiles(data.BuildPaths.ArtifactsRoot.FullPath + "/**/LibGit2Sharp*");
-    var unmanaged = context.GetFiles(data.BuildPaths.ArtifactsRoot.FullPath + "/net6.0/runtimes/**/*");
+    var unmanaged = context.GetFiles(data.BuildPaths.ArtifactsRoot.FullPath + "/net8.0/runtimes/**/*");
 
     data.NuGetPackSettings.Description += Environment.NewLine + Environment.NewLine + 
                                           "NOTE:" + Environment.NewLine + 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.100",
+    "version": "9.0.100",
     "rollForward": "feature"
   }
 }

--- a/src/Cake.Git/Cake.Git.csproj
+++ b/src/Cake.Git/Cake.Git.csproj
@@ -20,7 +20,7 @@
   <ItemGroup>
     <PackageReference Include="LibGit2Sharp" Version="0.30.0" />
     <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="2.0.322" />
-    <PackageReference Include="Cake.Core" Version="4.0.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Core" Version="5.0.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Cake.Git/Cake.Git.csproj
+++ b/src/Cake.Git/Cake.Git.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net6.0;net7.0;net8.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>

--- a/test_net6.0.cake
+++ b/test_net6.0.cake
@@ -1,2 +1,0 @@
-#r "./tools/Addins/Cake.Git/Cake.Git/lib/net6.0/Cake.Git.dll"
-#load test.cake

--- a/test_net7.0.cake
+++ b/test_net7.0.cake
@@ -1,2 +1,0 @@
-#r "./tools/Addins/Cake.Git/Cake.Git/lib/net7.0/Cake.Git.dll"
-#load test.cake

--- a/test_net9.0.cake
+++ b/test_net9.0.cake
@@ -1,0 +1,2 @@
+#r "./tools/Addins/Cake.Git/Cake.Git/lib/net9.0/Cake.Git.dll"
+#load test.cake


### PR DESCRIPTION
Updates to support Cake 5.0:

* Builds against Cake 5.0
* Multi-Targets additionally .NET 9 and removes support for .NET 6 & .NET 7
* Updates build to Cake 5.0

Fixes #193
Fixes #194