### PR TITLE
 Update to Cake 6.0 and .NET 10

### DIFF
--- a/.config/dotnet-tools.json
+++ b/.config/dotnet-tools.json
@@ -3,7 +3,7 @@
   "isRoot": true,
   "tools": {
     "cake.tool": {
-      "version": "5.0.0",
+      "version": "6.2.0",
       "commands": [
         "dotnet-cake"
       ]

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,8 +6,9 @@ install:
   - ps: $env:DOTNET_INSTALL_DIR = "$pwd\.dotnetsdk"
   - ps: mkdir $env:DOTNET_INSTALL_DIR -Force | Out-Null
   - ps: Invoke-WebRequest -Uri "https://dotnet.microsoft.com/download/dotnet/scripts/v1/dotnet-install.ps1" -OutFile "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1"
-  - ps: '& "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1" -Version 8.0.404 -InstallDir $env:DOTNET_INSTALL_DIR'
-  - ps: '& "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1" -Version 9.0.100 -InstallDir $env:DOTNET_INSTALL_DIR'
+  - ps: '& "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1" -Version 8.0.421 -InstallDir $env:DOTNET_INSTALL_DIR'
+  - ps: '& "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1" -Version 9.0.314 -InstallDir $env:DOTNET_INSTALL_DIR'
+  - ps: '& "$($env:DOTNET_INSTALL_DIR)/dotnet-install.ps1" -Version 10.0.300 -InstallDir $env:DOTNET_INSTALL_DIR'
   - ps: $env:Path = "$env:DOTNET_INSTALL_DIR;$env:Path"
   - ps: dotnet --info
 

--- a/build.cake
+++ b/build.cake
@@ -76,7 +76,7 @@ Setup(ctx =>
         isLocalBuild,
         configuration,
         target,
-        new[]{ "net8.0", "net9.0" },
+        new[]{ "net8.0", "net9.0", "net10.0" },
         new DotNetMSBuildSettings()
                             .WithProperty("Version", semVersion)
                             .WithProperty("AssemblyVersion", version)
@@ -213,7 +213,7 @@ Task("Publish-Artifacts")
 Task("Create-NuGet-Package")
     .IsDependentOn("Create-NuGet-Package-Scripting")
     .IsDependentOn("Create-NuGet-Package-Frosting");
-    
+
 Task("Create-NuGet-Package-Scripting")
     .IsDependentOn("Publish-Artifacts")
     .Does<BuildData>(static (context, data) =>
@@ -223,8 +223,8 @@ Task("Create-NuGet-Package-Scripting")
     var libGit = context.GetFiles(data.BuildPaths.ArtifactsRoot.FullPath + "/**/LibGit2Sharp*");
     var unmanaged = context.GetFiles(data.BuildPaths.ArtifactsRoot.FullPath + "/net8.0/runtimes/**/*");
 
-    data.NuGetPackSettings.Description += Environment.NewLine + Environment.NewLine + 
-                                          "NOTE:" + Environment.NewLine + 
+    data.NuGetPackSettings.Description += Environment.NewLine + Environment.NewLine +
+                                          "NOTE:" + Environment.NewLine +
                                           "The addin currently only runs on x64 processors. ARM processors are not supported." + Environment.NewLine +
                                           "This is the version of the addin compatible with Cake Script Runners." + Environment.NewLine +
                                           "For addin compatible with Cake Frosting see Cake.Frosting.Git.";
@@ -267,8 +267,8 @@ Task("Create-NuGet-Package-Frosting")
     var cakeGitDoc = context.GetFiles(data.BuildPaths.ArtifactsRoot.FullPath + "/**/Cake.Git.xml");
 
     data.NuGetPackSettings.Id = "Cake.Frosting.Git";
-    data.NuGetPackSettings.Description += Environment.NewLine + Environment.NewLine + 
-                                          "NOTE:" + Environment.NewLine + 
+    data.NuGetPackSettings.Description += Environment.NewLine + Environment.NewLine +
+                                          "NOTE:" + Environment.NewLine +
                                           "This is the version of the addin compatible with Cake Frosting." + Environment.NewLine +
                                           "For addin compatible with Cake Script Runners see Cake.Git." + Environment.NewLine;
     data.NuGetPackSettings.Files =  (cakeGit + cakeGitDoc)
@@ -286,7 +286,7 @@ Task("Create-NuGet-Package-Frosting")
                                     .ToArray();
     data.NuGetPackSettings.Dependencies = new List<NuSpecDependency>
     {
-        new NuSpecDependency { Id = "Cake.Core", Version = "5.0.0" },
+        new NuSpecDependency { Id = "Cake.Core", Version = "6.2.0" },
         new NuSpecDependency { Id = "LibGit2Sharp", Version = "0.30.0" }
     };
 

--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "9.0.100",
+    "version": "10.0.100",
     "rollForward": "feature"
   }
 }

--- a/src/Cake.Git/Cake.Git.csproj
+++ b/src/Cake.Git/Cake.Git.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <AllowedOutputExtensionsInPackageBuildOutputFolder>$(AllowedOutputExtensionsInPackageBuildOutputFolder);.pdb</AllowedOutputExtensionsInPackageBuildOutputFolder>
   </PropertyGroup>

--- a/src/Cake.Git/Cake.Git.csproj
+++ b/src/Cake.Git/Cake.Git.csproj
@@ -20,7 +20,7 @@
   <ItemGroup>
     <PackageReference Include="LibGit2Sharp" Version="0.30.0" />
     <PackageReference Include="LibGit2Sharp.NativeBinaries" Version="2.0.322" />
-    <PackageReference Include="Cake.Core" Version="5.0.0" PrivateAssets="All" />
+    <PackageReference Include="Cake.Core" Version="6.2.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>
   <ItemGroup>

--- a/test_net10.0.cake
+++ b/test_net10.0.cake
@@ -1,0 +1,2 @@
+#r "./tools/Addins/Cake.Git/Cake.Git/lib/net10.0/Cake.Git.dll"
+#load test.cake


### PR DESCRIPTION
Modeled after #195

Update to support Cake 6.0 and .NET 10

See also:
- https://cakebuild.net/blog/2025/11/cake-v6.0.0-released
- https://learn.microsoft.com/en-us/dotnet/core/whats-new/dotnet-10/overview